### PR TITLE
Remove Bad Apostrophe from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ layout: default
 		<div class="row">
 			<div class="col-md-12">
 				<h2 id="performance">Performance</h2>
-				<p><small>Phproject has been designed from the beginning to be fast. Database queries run are kept very simple and consistent, and we've made every effort to keep the number of queries needed to generate each page at an absolute minimum. It uses the <a href="http://fatfreeframework.com/" target="_blank">Fat-Free Framework</a> as it's base, allowing it to have a simple but powerful feature set without compromising performance. Every template file is compiled at run time, and only needs to be recompiled when the code is changed. Phproject also includes internal caching that prevents slow duplicate database queries from being used, such as table schema lookups, which greatly increases performance on large pages with lots of data.</small></p>
+				<p><small>Phproject has been designed from the beginning to be fast. Database queries run are kept very simple and consistent, and we've made every effort to keep the number of queries needed to generate each page at an absolute minimum. It uses the <a href="http://fatfreeframework.com/" target="_blank">Fat-Free Framework</a> as its base, allowing it to have a simple but powerful feature set without compromising performance. Every template file is compiled at run time, and only needs to be recompiled when the code is changed. Phproject also includes internal caching that prevents slow duplicate database queries from being used, such as table schema lookups, which greatly increases performance on large pages with lots of data.</small></p>
 				<br>
 			</div>
 		</div>


### PR DESCRIPTION
The text "as its base" should not have an apostrophe.

Don't believe me?  Ask [The Oatmeal](http://theoatmeal.com/comics/apostrophe) -- look for the singing velociraptor.