### PR TITLE
F3 v3.5.0 compatibility fixes

### DIFF
--- a/app/view/error/inline.html
+++ b/app/view/error/inline.html
@@ -2,12 +2,9 @@
 	<p class="lead"><strong><?php echo $f3->get("ERROR.code"); ?></strong> <?php echo $f3->get("ERROR.status"); ?></p>
 	<p><?php echo $f3->get("ERROR.text"); ?></p>
 	<?php if($f3->get("DEBUG") >= 2) { ?>
-		<dl>
-			<?php foreach($f3->get("ERROR.trace") as $line) { ?>
-				<dt><?php echo $line["file"]; ?></dt>
-				<dd><?php echo $line["line"]; ?>: <?php echo $line["class"], $line["type"], $line["function"], "(", implode(", ", $line["args"]), ")"; ?></dd>
-			<?php } ?>
-		</dl>
+		<div>
+			<?php echo nl2br($f3->get("ERROR.trace")); ?>
+		</div>
 	<?php } ?>
 	<?php if($f3->get("DEBUG") >= 3) { ?>
 		<pre><?php echo $f3->get("db.instance")->log(); ?></pre>

--- a/index.php
+++ b/index.php
@@ -111,6 +111,10 @@ foreach($pluginDir as $pluginName) {
 }
 $f3->set("plugins", $plugins);
 
+// register filter
+\Helper\View::instance()->filter('parseText','$this->parseText');
+\Helper\View::instance()->filter('formatFilesize','$this->formatFilesize');
+
 // Set up user session
 $user = new Model\User();
 $user->loadCurrent();


### PR DESCRIPTION
the ERROR.trace was adjusted (it's a simple multiline string or [highlighted](http://fatfreeframework.com/quick-reference#HIGHLIGHT) html text now) and new token filters need to be [registered](http://fatfreeframework.com/preview#filter) now, instead of extending the class, for better decoupling.

NB: you'll notice that the current version is broken, when you clear the `tmp/` folder and try to view some issue details 