### PR TITLE
base path issue in config importer

### DIFF
--- a/app/model/config.php
+++ b/app/model/config.php
@@ -30,7 +30,7 @@ class Config extends \Model {
 	 */
 	public static function importAll() {
 		$f3 = \Base::instance();
-		$root = $f3->get('ROOT');
+		$root = $f3->get('ROOT').$f3->get('BASE');
 
 		// Import existing config
 		$ini = parse_ini_file($root.'/config.ini');


### PR DESCRIPTION
Updated phproject today and hit a little issue:

```
500 Internal Server Error

parse_ini_file(/var/www/config.ini): failed to open stream: No such file or directory
[dev/foo/tickets/lib/base.php:2015] Base->error()
[dev/foo/tickets/app/model/config.php:36] parse_ini_file()
[dev/foo/tickets/app/model/config.php:22] Model\Config::importAll()
[dev/foo/tickets/index.php:68] Model\Config::loadAll()	
```
It was just the wrong path here. It's also not sure to write the config file there, as it could be that it's read-only and has no write-access. But since this portion is a upgrade code mechanism, I guess it doesn't hurt that much.