### PR TITLE
Prevent redirect to /issues/new/... right after modal dialog appeared

### DIFF
--- a/js/taskboard.js
+++ b/js/taskboard.js
@@ -58,8 +58,8 @@ var Taskboard = {
 
 		// Initialize add buttons on stories
 		$(".add-task").click(function(e) {
-			Taskboard.modalAdd($(this).parents('.tb-row').data("story-id"));
 			e.preventDefault();
+			Taskboard.modalAdd($(this).parents('.tb-row').data("story-id"));
 		});
 
 		// Handle add/edit form submission


### PR DESCRIPTION
I couln't reproduce it on the http://demo.phproject.org/ . But locally right after modal dialog "Add task" appeared, page redirects to a "/issues/new/xx/xx" (tested on Chrome and Firefox)