### PR TITLE
feat(issues): restrict to user group or admin

### DIFF
--- a/app/helper/dashboard.php
+++ b/app/helper/dashboard.php
@@ -6,6 +6,8 @@ class Dashboard extends \Prefab
 {
     protected $_issue;
     protected $_ownerIds;
+    protected $_groupIds;
+    protected $_groupUserIds;
     protected $_projects;
     protected $_order = "priority DESC, has_due_date ASC, due_date ASC, created_date DESC";
 
@@ -33,6 +35,35 @@ class Dashboard extends \Prefab
             $this->_ownerIds[] = $r->group_id;
         }
         return $this->_ownerIds;
+    }
+
+    public function getGroupIds()
+    {
+        if ($this->_groupIds) {
+            return $this->_groupIds;
+        }
+        $f3 = \Base::instance();
+        $groups = new \Model\User\Group();
+        foreach ($groups->find(array("user_id = ?", $f3->get("user.id"))) as $r) {
+            $this->_groupIds[] = $r->group_id;
+        }
+        return $this->_groupIds;
+    }
+
+    public function getGroupUserIds()
+    {
+        if ($this->_groupUserIds) {
+            return $this->_groupUserIds;
+        }
+        $f3 = \Base::instance();
+        $groups = new \Model\User\Group();
+        
+        $groupString = implode(",", $this->getGroupIds()) ;     
+
+        foreach ($groups->find(array("group_id IN (" . $groupString  . ")"  ) ) as $r) {
+            $this->_groupUserIds[] = $r->user_id;
+        }
+        return $this->_groupUserIds;
     }
 
     public function projects()


### PR DESCRIPTION
@Alanaktion  Great work on this.

This is based on the work done by @GelLiNN  and @Citydampf. It differs from @GelLiNN's method in that no database changes are made. The group access is determined by querying the existing tables.

I would like to add a configuration option to allow the administrator to turn on or off this filtering but don't have that much experience with UI.