### PR TITLE
CLI Installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+services:
+  - mysql
+before_install:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS phproject;'
 install:
-  - composer install
+  - composer install --no-ansi --no-interaction
 before_script:
   - if find . -name "*.php" ! -path "./vendor/*"  -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
 script:
   - php vendor/bin/phpcs
+  - php install.php --site-name=Test --site-url=http://localhost/ --admin-username=test --admin-email=test@example.com --admin-password=secret --db-host=127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
   - if find . -name "*.php" ! -path "./vendor/*"  -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
 script:
   - php vendor/bin/phpcs
-  - php install.php --site-name=Test --site-url=http://localhost/ --admin-username=test --admin-email=test@example.com --admin-password=secret --db-host=127.0.0.1
+  - php install.php --site-name=Test --site-url=http://localhost/ --admin-username=test --admin-email=test@example.com --admin-password=secret --db-host=127.0.0.1 --db-user=root

--- a/app/helper/cli.php
+++ b/app/helper/cli.php
@@ -45,7 +45,7 @@ class Cli extends \Prefab
         $result = [];
         foreach ($keys as $o) {
             $key = rtrim($o, ':');
-            $result[$key] = $data[$key] ?? $options[$key];
+            $result[$key] = $data[$key] ?? $options[$o];
         }
         return $result;
     }

--- a/app/helper/cli.php
+++ b/app/helper/cli.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Helper;
+
+class Cli extends \Prefab
+{
+    /**
+     * Parse CLI options with defaults
+     *
+     * Also shows argument help if "-h" or "--help" is passed, and exits
+     * with a relevant message if required arguments are not specified.
+     *
+     * @param array $options Associative array, argument keys => default values
+     * @param array $argv
+     * @return array|null
+     */
+    public function parseOptions(array $options, ?array $argv = null): ?array
+    {
+        $keys = array_keys($options);
+        if ($argv === null) {
+            $argv = $_SERVER['argv'];
+        }
+
+        // Show argument help
+        if (getopt('h', ['help']) || count($argv) == 1) {
+            return $this->showHelp($keys, $options);
+        }
+
+        // Parse options
+        $data = getopt('', $keys);
+
+        // Check that required options are set
+        foreach ($keys as $key) {
+            if (substr_count($key, ':') != 1) {
+                continue;
+            }
+            $o = rtrim($key, ':');
+            if (!array_key_exists($o, $data)) {
+                echo "Required argument --$o not specified.", PHP_EOL;
+                exit(1);
+            }
+        }
+
+        // Fill result with defaults
+        $result = [];
+        foreach ($keys as $o) {
+            $key = rtrim($o, ':');
+            $result[$key] = $data[$key] ?? $options[$key];
+        }
+        return $result;
+    }
+
+    /**
+     * Output help message showing parseOptions() options and defaults
+     */
+    protected function showHelp(array $options, array $defaultMap): void
+    {
+        $required = [];
+        $optional = [];
+        $flags = [];
+        foreach ($options as $o) {
+            $colons = substr_count($o, ':');
+            if ($colons == 2) {
+                $optional[] = $o;
+            } elseif ($colons == 1) {
+                $required[] = $o;
+            } else {
+                $flags[] = $o;
+            }
+        }
+
+        echo 'Required values:', PHP_EOL;
+        foreach ($required as $key) {
+            $o = rtrim($key, ':');
+            echo "--$o={$defaultMap[$key]}", PHP_EOL;
+        }
+        echo PHP_EOL;
+
+        echo 'Optional values:', PHP_EOL;
+        foreach ($optional as $key) {
+            $o = rtrim($key, ':');
+            echo "--$o={$defaultMap[$key]}", PHP_EOL;
+        }
+        echo PHP_EOL;
+
+        echo 'Optional flags:', PHP_EOL;
+        foreach ($flags as $key) {
+            $o = rtrim($key, ':');
+            echo "--$o", PHP_EOL;
+        }
+        echo PHP_EOL;
+    }
+}


### PR DESCRIPTION
This adds support for initializing a Phproject installation via command-line.

Documentation will be updated shortly, but the basic usage can be seen with the `--help` flag:

```bash
php install.php --help
```